### PR TITLE
metric&peerstore

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -38,6 +38,10 @@ libp2prs-traits = { path = "../traits", version = "0.1.0", package = "libp2prs-t
 ring = { version = "0.16.9", features = ["alloc", "std"], default-features = true }
 salsa20 = "0.3.0"
 sha3 = "0.8"
+serde = { version = "1.0.117", features = ["derive"] }
+#leveldb = "0.8.6"
+serde_json = "1.0.59"
+async-std = "1.6.2"
 
 [dev-dependencies]
 async-std = "1.6.2"

--- a/swarm/Cargo.toml
+++ b/swarm/Cargo.toml
@@ -19,6 +19,8 @@ fnv = "1.0"
 smallvec = "1.0"
 prost = "0.6"
 void = "1"
+env_logger = "0.8.1"
+crossbeam-epoch = "0.9.0"
 libp2prs-traits = { path = "../traits", version = "0.1.0", package = "libp2prs-traits" }
 libp2prs-core = { path = "../core", version = "0.1.0", package = "libp2prs-core" }
 

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -51,6 +51,7 @@ mod network;
 mod registry;
 
 pub mod identify;
+pub mod metrics;
 pub mod ping;
 pub mod protocol_handler;
 pub mod substream;
@@ -80,12 +81,14 @@ use libp2prs_core::{
 use crate::connection::{Connection, ConnectionId, ConnectionLimit, Direction};
 use crate::control::SwarmControlCmd;
 use crate::identify::{IdentifyConfig, IdentifyHandler, IdentifyInfo, IdentifyPushHandler};
+use crate::metrics::metric::Metric;
 use crate::muxer::Muxer;
 use crate::network::NetworkInfo;
 use crate::ping::{PingConfig, PingHandler};
 use crate::protocol_handler::IProtocolHandler;
 use crate::registry::Addresses;
-use crate::substream::{RemotePeerInfo, StreamId, Substream};
+use crate::substream::{ConnectInfo, StreamId, Substream};
+use std::sync::Arc;
 
 type Result<T> = std::result::Result<T, SwarmError>;
 
@@ -208,6 +211,8 @@ pub enum SwarmEvent {
         /// Duration means the TTL when succeeded, or SwarmError for failed.
         result: Result<(IdentifyInfo, Multiaddr)>,
     },
+    /// Close swarm
+    SwarmClosed,
 }
 
 type ProtocolId = &'static [u8];
@@ -235,6 +240,9 @@ pub struct Swarm {
     /// List of multiaddresses we're listening on, after account for external IP addresses and
     /// similar mechanisms.
     external_addrs: Addresses,
+
+    /// Metrics. Monitor the network resource that spend on connection
+    metric: Arc<Metric>,
 
     /// List of nodes for which we deny any incoming connection.
     banned_peers: HashSet<PeerId>,
@@ -282,6 +290,14 @@ impl Swarm {
         let mut peers = PeerStore::default();
         peers.keys.add_key(&key.clone().into_peer_id(), key.clone());
 
+        task::block_on(async {
+            if let Err(e) = peers.load_data().await {
+                println!("{}", e);
+            }
+        });
+
+        let metric = Metric::new();
+
         Swarm {
             peers,
             muxer: Muxer::new(),
@@ -294,6 +310,7 @@ impl Swarm {
             banned_peers: Default::default(),
             connections_by_id: Default::default(),
             connections_by_peer: Default::default(),
+            metric: Arc::new(metric),
             event_receiver: event_rx,
             event_sender: event_tx,
             ctrl_receiver: ctrl_rx,
@@ -346,6 +363,11 @@ impl Swarm {
         self.muxer.add_protocol_handler(Box::new(PingHandler::new(ping)));
         self
     }
+    /// Creates Swarm with Metrics.
+    pub fn with_metric(mut self, metric: Metric) -> Self {
+        self.metric = Arc::new(metric);
+        self
+    }
     /// Creates Swarm with Identify service.
     pub fn with_identify(mut self, config: IdentifyConfig) -> Self {
         let handler = IdentifyHandler::new(self.ctrl_sender.clone());
@@ -356,7 +378,7 @@ impl Swarm {
     }
     /// Get a controller for Swarm.
     pub fn control(&self) -> Control {
-        Control::new(self.ctrl_sender.clone())
+        Control::new(self.ctrl_sender.clone(), self.metric.clone())
     }
 
     /// Makes progress for Swarm
@@ -432,6 +454,9 @@ impl Swarm {
             SwarmEvent::IdentifyResult { cid, result } => {
                 let _ = self.handle_identify_result(cid, result);
             }
+            SwarmEvent::SwarmClosed => {
+                let _ = self.handle_swarm_closed();
+            }
 
             // TODO: handle other messages
             e => {
@@ -476,6 +501,7 @@ impl Swarm {
             }
             SwarmControlCmd::CloseSwarm => {
                 log::info!("closing the swarm...");
+                let _ = self.on_close_swarm().await;
                 let _ = self.event_sender.close_channel();
             } // TODO:
               //_ => {}
@@ -526,6 +552,13 @@ impl Swarm {
         //self.handle_stream_closed(Direction::Outbound, cid, sid);
         Ok(())
     }
+
+    /// Close swarm
+    async fn on_close_swarm(&mut self) -> Result<()> {
+        let _ = self.event_sender.send(SwarmEvent::SwarmClosed).await;
+        Ok(())
+    }
+
     ///
     fn on_retrieve_network_info(&mut self, f: impl FnOnce(Result<NetworkInfo>)) -> Result<()> {
         f(Ok(self.network_info()));
@@ -947,10 +980,12 @@ impl Swarm {
     fn handle_connection_opened(&mut self, stream_muxer: IStreamMuxer, dir: Direction) -> Result<()> {
         log::trace!("handle_connection_opened: {:?} {:?}", stream_muxer, dir);
 
+        let metric = self.metric.clone();
         let pid = self.local_peer_id.clone();
         let pubkey = stream_muxer.clone().local_priv_key().public();
 
         self.peers.keys.add_key(&pid, pubkey);
+        // Save peer_id into metric
 
         // clone the stream_muxer, and then wrap into Connection, task_handle will be assigned later
         let mut connection = Connection::new(
@@ -959,6 +994,7 @@ impl Swarm {
             dir,
             self.event_sender.clone(),
             self.ctrl_sender.clone(),
+            metric.clone(),
         );
 
         // TODO: filtering the multiaddr, Err = AddrFiltered(addr)
@@ -991,6 +1027,7 @@ impl Swarm {
             // start the background task of the stream_muxer, the handle can be await'ed by us
             let task_handle = stream_muxer.task().map(task::spawn);
             loop {
+                let metric = metric.clone();
                 let ctrl = ctrl.clone();
                 let r = stream_muxer.accept_stream().await;
 
@@ -1009,8 +1046,8 @@ impl Swarm {
                                 let la = stream_muxer.local_multiaddr();
                                 let ra = stream_muxer.remote_multiaddr();
                                 let rpid = stream_muxer.remote_peer();
-                                let ri = RemotePeerInfo { ra, rpid };
-                                let stream = Substream::new(raw_stream, Direction::Inbound, proto, cid, la, ri, ctrl);
+                                let ci = ConnectInfo { la, ra, rpid };
+                                let stream = Substream::new(raw_stream, metric, Direction::Inbound, proto, cid, ci, ctrl);
                                 let sub_stream = stream.clone();
                                 let _ = tx.send(SwarmEvent::StreamOpened { sub_stream }).await;
 
@@ -1120,6 +1157,8 @@ impl Swarm {
         log::info!("after close {:?}", self.connections_by_id);
         log::info!("after close {:?}", self.connections_by_peer);
 
+        log::info!("close {:?}", self.peers.addrs);
+
         Ok(())
     }
 
@@ -1173,6 +1212,19 @@ impl Swarm {
             }
         }
 
+        Ok(())
+    }
+
+    /// Handles closing a swarm
+    ///
+    ///
+    fn handle_swarm_closed(&mut self) -> Result<()> {
+        log::info!("Exiting...");
+        task::block_on(async {
+            if let Err(e) = self.peers.save_data().await {
+                println!("{}", e);
+            }
+        });
         Ok(())
     }
 

--- a/swarm/src/metrics/metric.rs
+++ b/swarm/src/metrics/metric.rs
@@ -1,0 +1,193 @@
+use crate::metrics::metricmap::MetricMap;
+use crate::ProtocolId;
+use libp2prs_core::PeerId;
+use std::fmt;
+use std::ops::Add;
+use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+pub struct Metric {
+    /// The accumulative counter of packets sent.
+    pkt_sent: AtomicUsize,
+    /// The accumulative counter of packets received.
+    pkt_recv: AtomicUsize,
+    /// The accumulative counter of bytes sent.
+    byte_sent: AtomicUsize,
+    /// The accumulative counter of bytes received.
+    byte_recv: AtomicUsize,
+
+    /// A hashmap that key is protocol name and value is a counter of bytes received.
+    protocol_in: MetricMap<ProtocolId, usize>,
+    /// A hashmap that key is protocol name and value is a counter of bytes sent.
+    protocol_out: MetricMap<ProtocolId, usize>,
+
+    /// A hashmap that key is peer_id and value is a counter of bytes received.
+    peer_in: MetricMap<PeerId, usize>,
+    /// A hashmap that key is peer_id and value is a counter of bytes sent.
+    peer_out: MetricMap<PeerId, usize>,
+}
+
+impl fmt::Debug for Metric {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Metric")
+            .field("pkt_sent", &self.pkt_sent)
+            .field("pkt_recv", &self.pkt_recv)
+            .field("byte_sent", &self.byte_sent)
+            .field("byte_recv", &self.byte_recv)
+            .field("protocol_in", &self.protocol_in)
+            .field("protocol_out", &self.protocol_out)
+            .field("peer_in", &self.peer_in)
+            .field("peer_out", &self.peer_out)
+            .finish()
+    }
+}
+
+impl Default for Metric {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Metric {
+    /// Create a new metric
+    pub fn new() -> Metric {
+        Metric {
+            pkt_sent: AtomicUsize::new(0),
+            pkt_recv: AtomicUsize::new(0),
+            byte_sent: AtomicUsize::new(0),
+            byte_recv: AtomicUsize::new(0),
+            protocol_in: MetricMap::new(),
+            protocol_out: MetricMap::new(),
+            peer_in: MetricMap::new(),
+            peer_out: MetricMap::new(),
+        }
+    }
+
+    #[inline]
+    pub(crate) fn log_recv_msg(&self, n: usize) {
+        self.pkt_recv.fetch_add(1, Ordering::SeqCst);
+        self.byte_recv.fetch_add(n, Ordering::SeqCst);
+    }
+
+    #[inline]
+    pub(crate) fn log_sent_msg(&self, n: usize) {
+        self.pkt_sent.fetch_add(1, Ordering::SeqCst);
+        self.byte_sent.fetch_add(n, Ordering::SeqCst);
+    }
+
+    #[inline]
+    pub(crate) fn log_sent_stream(&self, protocol: ProtocolId, count: usize, peer_id: &PeerId) {
+        self.protocol_out.store_or_modify(&protocol, count, |_, value| value.add(count));
+        self.peer_out.store_or_modify(peer_id, count, |_, value| value.add(count));
+    }
+
+    #[inline]
+    pub(crate) fn log_recv_stream(&self, protocol: ProtocolId, count: usize, peer_id: &PeerId) {
+        self.protocol_in.store_or_modify(&protocol, count, |_, value| value.add(count));
+        self.peer_in.store_or_modify(peer_id, count, |_, value| value.add(count));
+    }
+
+    /// Get count & bytes about received package
+    pub fn get_recv_count_and_size(&self) -> (usize, usize) {
+        (self.pkt_recv.load(SeqCst), self.byte_recv.load(SeqCst))
+    }
+
+    /// Get count & bytes about sent package
+    pub fn get_sent_count_and_size(&self) -> (usize, usize) {
+        (self.pkt_sent.load(SeqCst), self.byte_sent.load(SeqCst))
+    }
+
+    /// Get in&out bytes by protocol_id
+    pub fn get_protocol_in_and_out(&self, protocol_id: &ProtocolId) -> (Option<usize>, Option<usize>) {
+        let protocol_in = self.protocol_in.load(protocol_id);
+        let protocol_out = self.protocol_out.load(protocol_id);
+        (protocol_in, protocol_out)
+    }
+
+    /// Get in&out bytes by peer_id
+    pub fn get_peer_in_and_out(&self, peer_id: &PeerId) -> (Option<usize>, Option<usize>) {
+        let peer_in = self.peer_in.load(peer_id);
+        let peer_out = self.peer_out.load(peer_id);
+        (peer_in, peer_out)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::metrics::metric::Metric;
+    use crate::ProtocolId;
+    use async_std::task;
+    use libp2prs_core::PeerId;
+    use std::sync::Arc;
+
+    fn generate_metrics() -> Metric {
+        Metric::new()
+    }
+
+    #[test]
+    fn test_sent_package_and_byte() {
+        let metric = Arc::new(generate_metrics());
+
+        task::block_on(async {
+            let mut t = Vec::new();
+            for index in 0..16 {
+                let m = metric.clone();
+                t.push(task::spawn(async move {
+                    m.log_sent_msg(index);
+                }));
+            }
+            for item in t {
+                item.await;
+            }
+        });
+
+        assert_eq!(metric.get_sent_count_and_size(), (16, 120));
+    }
+
+    #[test]
+    fn test_recv_package_and_byte() {
+        let metric = Arc::new(generate_metrics());
+
+        task::block_on(async {
+            let mut t = Vec::new();
+            for index in 0..16 {
+                let m = metric.clone();
+                t.push(task::spawn(async move {
+                    m.log_recv_msg(index);
+                }));
+            }
+            for item in t {
+                item.await;
+            }
+        });
+
+        assert_eq!(metric.get_recv_count_and_size(), (16, 120));
+    }
+
+    #[test]
+    fn test_protocol_and_peer() {
+        // env_logger::builder().filter_level(LevelFilter::Info).init();
+        let metric = Arc::new(generate_metrics());
+
+        let peer_id = PeerId::random();
+        let protocol = ProtocolId::default();
+        task::block_on(async {
+            let mut t = Vec::new();
+            for i in 0..16 {
+                let m = metric.clone();
+                let pid = peer_id.clone();
+                t.push(task::spawn(async move {
+                    m.log_sent_stream(protocol, i, &pid);
+                    m.log_recv_stream(protocol, i, &pid);
+                }));
+            }
+
+            for item in t {
+                item.await;
+            }
+        });
+
+        assert_eq!(metric.get_peer_in_and_out(&peer_id), (Some(120), Some(120)));
+        assert_eq!(metric.get_protocol_in_and_out(&protocol), (Some(120), Some(120)));
+    }
+}

--- a/swarm/src/metrics/metricmap.rs
+++ b/swarm/src/metrics/metricmap.rs
@@ -1,0 +1,193 @@
+use crossbeam_epoch::{Atomic, Owned};
+use smallvec::alloc::fmt::{Debug, Display, Formatter};
+use std::collections::hash_map::IntoIter;
+use std::collections::HashMap;
+use std::fmt;
+use std::hash::Hash;
+use std::option::Option::Some;
+use std::sync::atomic::Ordering::SeqCst;
+
+/// MetricMap is a lock-free hash map that supports concurrent operations.
+pub struct MetricMap<K, V> {
+    data: Atomic<HashMap<K, V>>,
+}
+
+impl<K, V> fmt::Debug for MetricMap<K, V> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MetricMap").field("data", &self.data).finish()
+    }
+}
+
+impl<K, V> Default for MetricMap<K, V>
+where
+    K: Eq + Hash + Clone + Debug,
+    V: Clone + Display,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<K, V> MetricMap<K, V>
+where
+    K: Eq + Hash + Clone + Debug,
+    V: Clone + Display,
+{
+    /// Create a new MetricMap
+    pub fn new() -> Self {
+        MetricMap {
+            data: Atomic::new(HashMap::<K, V>::new()),
+        }
+    }
+
+    /// If map contains key, replaces original value with the result that return by F.
+    /// Otherwise, create a new key-value and insert.
+    pub fn store_or_modify<F: Fn(&K, &V) -> V>(&self, key: &K, value: V, on_modify: F) {
+        let guard = crossbeam_epoch::pin();
+
+        loop {
+            let shared = self.data.load(SeqCst, &guard);
+
+            let mut new_hash = HashMap::new();
+
+            match unsafe { shared.as_ref() } {
+                Some(old_hash) => {
+                    new_hash = old_hash.clone();
+                    if let Some(old_value) = new_hash.get(key) {
+                        let new_value = on_modify(key, old_value);
+                        new_hash.insert(key.clone(), new_value.clone());
+                    } else {
+                        new_hash.insert(key.clone(), value.clone());
+                    }
+                }
+                None => {
+                    new_hash.insert(key.clone(), value.clone());
+                }
+            }
+
+            let owned = Owned::new(new_hash);
+
+            match self.data.compare_and_set(shared, owned, SeqCst, &guard) {
+                Ok(_) => {
+                    unsafe {
+                        guard.defer_destroy(shared);
+                        break;
+                    }
+                    // break;
+                }
+                Err(_e) => {}
+            }
+        }
+    }
+
+    pub fn load(&self, key: &K) -> Option<V> {
+        let guard = crossbeam_epoch::pin();
+
+        let shared = self.data.load(SeqCst, &guard);
+
+        let hmap = unsafe { shared.as_ref().unwrap() };
+
+        match hmap.get(key) {
+            Some(value) => Some(value.clone()),
+            None => None,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn delete(&self, key: K) {
+        let guard = crossbeam_epoch::pin();
+
+        loop {
+            let shared = self.data.load(SeqCst, &guard);
+
+            let old_hash = unsafe { shared.as_ref().unwrap() };
+
+            let mut new_hash = HashMap::new();
+            for (k, v) in old_hash {
+                if k.clone() == key {
+                    continue;
+                }
+                new_hash.insert(k.clone(), v.clone());
+            }
+
+            let owned = Owned::new(new_hash);
+
+            match self.data.compare_and_set(shared, owned, SeqCst, &guard) {
+                Ok(_) => unsafe {
+                    guard.defer_destroy(shared);
+                    break;
+                },
+                Err(_e) => {
+                    // Err(io::Error::new(io::ErrorKind::InvalidData, e.to_string()))
+                }
+            }
+        }
+    }
+
+    /// Return an iterator
+    pub fn iterator(&self) -> Option<IntoIter<K, V>> {
+        let guard = crossbeam_epoch::pin();
+
+        let shared = self.data.load(SeqCst, &guard);
+
+        match unsafe { shared.as_ref() } {
+            Some(map) => Some(map.clone().into_iter()),
+            None => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::metrics::metricmap::MetricMap;
+    use async_std::task;
+    use smallvec::alloc::sync::Arc;
+    use std::ops::Add;
+
+    #[test]
+    pub fn test_store_and_modify() {
+        let key = String::from("abc");
+        let map = Arc::new(MetricMap::new());
+        task::block_on(async {
+            let inside_future_map = map.clone();
+            for index in 0..16 {
+                let k = key.clone();
+                let inside_map = inside_future_map.clone();
+
+                task::spawn(async move { inside_map.store_or_modify(&k, index, |_, value| value.add(index)) }).await;
+            }
+        });
+
+        assert_eq!(map.load(&key), Some(120))
+    }
+
+    #[test]
+    pub fn test_delete() {
+        let key = String::from("abc");
+        let map = Arc::new(MetricMap::new());
+
+        task::block_on(async {
+            let delete_map = map.clone();
+            for index in 0..18 {
+                let k = key.clone();
+                let inside_map = delete_map.clone();
+
+                task::spawn(async move { inside_map.store_or_modify(&k, index, |_, value| value.add(index)) }).await;
+            }
+
+            map.delete(key.clone());
+
+            assert_eq!(map.load(&key), None);
+
+            for index in 0..20 {
+                let inside_map = delete_map.clone();
+                let k = key.clone();
+                task::spawn(async move { inside_map.store_or_modify(&k, index, |_, value| value.add(index)) }).await;
+            }
+        });
+
+        map.delete(key.clone());
+
+        assert_eq!(map.load(&key), None)
+    }
+}

--- a/swarm/src/metrics/mod.rs
+++ b/swarm/src/metrics/mod.rs
@@ -1,0 +1,2 @@
+pub mod metric;
+pub mod metricmap;


### PR DESCRIPTION
The purpose of this PR is to support metric, which provides for monitoring the flow of network traffic in and out of Swarm throughout.
Besides, peerstore can persist data to local storage. Default path is ./ds_addr_book.txt.