### PR TITLE
Support Prometheus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ libp2prs-dns = { path = "transports/dns", version = "0.1.0", package = "libp2prs
 libp2prs-websocket = { path = "transports/websocket", version = "0.1.0", package = "libp2prs-websocket" }
 libp2prs-swarm = { path = "swarm", version = "0.1.0", package = "libp2prs-swarm" }
 libp2prs-infoserver = { path="infoserver", version = "0.1.0", package = "libp2prs-infoserver" }
-
+libp2prs-exporter = { path="exporter", version = "0.1.0", package = "libp2prs-exporter" }
 
 async-std = { version = "1.6", features = ["attributes", "unstable"] }
 async-trait = "0.1"

--- a/examples/swarm_simple.rs
+++ b/examples/swarm_simple.rs
@@ -29,6 +29,7 @@ use libp2prs_core::transport::memory::MemoryTransport;
 use libp2prs_core::transport::upgrade::TransportUpgrade;
 use libp2prs_core::upgrade::{Selector, UpgradeInfo};
 use libp2prs_core::{Multiaddr, PeerId};
+use libp2prs_exporter::ExporterServer;
 use libp2prs_infoserver::InfoServer;
 use libp2prs_mplex as mplex;
 use libp2prs_secio as secio;
@@ -116,9 +117,11 @@ fn run_server() {
 
     swarm.listen_on(vec![listen_addr1, listen_addr2]).unwrap();
 
-    let monitor = InfoServer::new(control);
+    let monitor = InfoServer::new(control.clone());
 
     monitor.start("127.0.0.1:8999".to_string());
+
+    ExporterServer::new(control).start("127.0.0.1:9102".to_string());
 
     swarm.start();
 

--- a/exporter/Cargo.toml
+++ b/exporter/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "libp2prs-exporter"
+version = "0.1.0"
+license = "MIT"
+description = "The libp2p exporter"
+authors = ["Netwarps Technologies admin@paradeum.com"]
+repository = "https://github.com/netwarps/libp2p-rs"
+keywords = ["peer-to-peer", "libp2p", "networking"]
+categories = ["network-programming", "asynchronous"]
+edition = "2018"
+
+[dependencies]
+async-std = "1.6"
+log = "0.4"
+futures = "0.3.1"
+tide = "0.15.0"
+serde = { version = "1.0.117", features = ["derive"] }
+serde_json = "1.0.59"
+lazy_static = "1.4.0"
+prometheus = "0.10.0"
+libp2prs-swarm = { path = "../swarm", version = "0.1.0", package = "libp2prs-swarm" }
+libp2prs-core = { path = "../core", version = "0.1.0", package = "libp2prs-core" }
+
+[dev-dependencies]
+quickcheck = "0.9.0"
+rand = "0.7.2"
+env_logger = "0.8.1"

--- a/exporter/README.md
+++ b/exporter/README.md
@@ -1,0 +1,15 @@
+# libp2prs-infoserver
+
+> A visual interface about metric.
+
+This is a web api-server that observe swarm's metric.
+
+## Usage
+```
+    let keypair = Keypair::generate_ed25519_fixed();
+    let swarm = Swarm::new(keypair.public());
+    let control = swarm.control();
+    
+    let monitor = InfoServer::new(control);
+    monitor.start("127.0.0.1:8999".to_string());
+```

--- a/exporter/src/exporter.rs
+++ b/exporter/src/exporter.rs
@@ -1,0 +1,119 @@
+use futures::executor::block_on;
+use libp2prs_swarm::Control;
+use prometheus::core::{Collector, Desc};
+use prometheus::Counter;
+use prometheus::{proto, CounterVec, Opts};
+use std::collections::HashMap;
+
+/// Exporter is used to expose Metrics data.
+pub(crate) struct Exporter {
+    control: Control,
+    desc: Desc,
+}
+
+impl Collector for Exporter {
+    fn desc(&self) -> Vec<&Desc> {
+        vec![&self.desc]
+    }
+
+    fn collect(&self) -> Vec<proto::MetricFamily> {
+        let mut family = Vec::<proto::MetricFamily>::new();
+
+        // recv data
+        let recv_count = Counter::new("recv_pkg_counts", "Total number of packages received").unwrap();
+        let recv_size = Counter::new("recv_pkg_bytes", "Total bytes of packages received").unwrap();
+        let (count, size) = self.control.get_recv_count_and_size();
+        recv_count.inc_by(count as f64);
+        recv_size.inc_by(size as f64);
+        family.push(recv_count.collect()[0].clone());
+        family.push(recv_size.collect()[0].clone());
+
+        // send data
+        let sent_count = Counter::new("sent_pkg_counts", "Total number of packages sent").unwrap();
+        let sent_size = Counter::new("sent_pkg_bytes", "Total size of packages sent").unwrap();
+        let (count, size) = self.control.get_sent_count_and_size();
+        sent_count.inc_by(count as f64);
+        sent_size.inc_by(size as f64);
+        family.push(sent_count.collect()[0].clone());
+        family.push(sent_size.collect()[0].clone());
+
+        // connection data
+        let mut state = self.control.clone();
+        block_on(async {
+            let info = state.retrieve_networkinfo().await.unwrap();
+            let connect_peer = Counter::new("peer_count", "Current number of connection peers").unwrap();
+            connect_peer.inc_by(info.num_peers as f64);
+            family.push(connect_peer.collect()[0].clone());
+            let connection_count = Counter::new("connection_count", "Current number of connections").unwrap();
+            connection_count.inc_by(info.num_connections as f64);
+            family.push(connection_count.collect()[0].clone());
+            let connection_pending = Counter::new("connection_pending", "Current num of pending connections").unwrap();
+            connection_pending.inc_by(info.num_connections_pending as f64);
+            family.push(connection_pending.collect()[0].clone());
+            let connection_established = Counter::new("connection_established", "Current num of established connections").unwrap();
+            connection_established.inc_by(info.num_connections_established as f64);
+            family.push(connection_established.collect()[0].clone());
+            let active_stream = Counter::new("active_stream", "Current num of active streams").unwrap();
+            active_stream.inc_by(info.num_active_streams as f64);
+            family.push(active_stream.collect()[0].clone());
+        });
+
+        // peer_in
+        let opt = Opts::new("peer_id_input_bytes", "Each peer input bytes");
+        let peer = CounterVec::new(opt, &["peer_id"]).unwrap();
+        for (k, v) in self.control.peer_in_iter() {
+            let mut map = HashMap::new();
+            let value = k.to_string();
+            map.insert("peer_id", value.as_str());
+            peer.with(&map).inc_by(v as f64);
+        }
+        family.push(peer.collect()[0].clone());
+
+        // peer_out
+        let opt = Opts::new("peer_id_output_bytes", "Each peer output bytes");
+        let peer = CounterVec::new(opt, &["peer_id"]).unwrap();
+        for (k, v) in self.control.peer_out_iter() {
+            let mut map = HashMap::new();
+            let value = k.to_string();
+            map.insert("peer_id", value.as_str());
+            peer.with(&map).inc_by(v as f64);
+        }
+        family.push(peer.collect()[0].clone());
+
+        // protocol_in
+        let opt = Opts::new("protocol_input_bytes", "Each protocol input bytes");
+        let protocol = CounterVec::new(opt, &["protocol"]).unwrap();
+        for (k, v) in self.control.protocol_in_iter() {
+            let mut map = HashMap::new();
+            let value = k.to_string();
+            map.insert("protocol", value.as_str());
+            protocol.with(&map).inc_by(v as f64);
+        }
+        family.push(protocol.collect()[0].clone());
+
+        // protocol_out
+        let opt = Opts::new("protocol_output_bytes", "Each protocol output bytes");
+        let protocol = CounterVec::new(opt, &["protocol"]).unwrap();
+        for (k, v) in self.control.protocol_out_iter() {
+            let mut map = HashMap::new();
+            let value = k.to_string();
+            map.insert("protocol", value.as_str());
+            protocol.with(&map).inc_by(v as f64);
+        }
+        family.push(protocol.collect()[0].clone());
+
+        family
+    }
+}
+
+impl Exporter {
+    pub fn new(control: Control) -> Self {
+        let d = Desc::new(
+            "libp2prs_exporter".into(),
+            "An Exporter that exposes metrics in libp2p_rs".into(),
+            vec![],
+            HashMap::new(),
+        );
+        Exporter { control, desc: d.unwrap() }
+    }
+}

--- a/exporter/src/lib.rs
+++ b/exporter/src/lib.rs
@@ -1,0 +1,44 @@
+pub(crate) mod exporter;
+
+use crate::exporter::Exporter;
+use async_std::task;
+use libp2prs_swarm::Control;
+use prometheus::{register, Encoder, TextEncoder};
+use tide::{Body, Request, Response, Server};
+
+/// Exporter server
+pub struct ExporterServer {
+    s: Server<()>,
+}
+
+impl ExporterServer {
+    pub fn new(control: Control) -> Self {
+        let mut s = tide::new();
+
+        // Register exporter to global registry, and then we can use default gather method.
+        let exporter = Exporter::new(control);
+        let _ = register(Box::new(exporter));
+        s.at("/metrics").get(get_metric);
+        ExporterServer { s }
+    }
+
+    pub fn start(self, addr: String) {
+        task::spawn(async move { self.s.listen(addr).await });
+    }
+}
+
+/// Return metrics to prometheus
+async fn get_metric(_: Request<()>) -> tide::Result {
+    let encoder = TextEncoder::new();
+    let metric_families = prometheus::gather();
+    let mut buffer = vec![];
+
+    encoder.encode(&metric_families, &mut buffer).unwrap();
+
+    let response = Response::builder(200)
+        .content_type("text/plain; version=0.0.4")
+        .body(Body::from(buffer))
+        .build();
+
+    Ok(response)
+}

--- a/swarm/src/control.rs
+++ b/swarm/src/control.rs
@@ -30,6 +30,7 @@ use crate::metrics::metric::Metric;
 use crate::network::NetworkInfo;
 use crate::substream::{StreamId, Substream};
 use crate::{ProtocolId, SwarmError};
+use std::collections::hash_map::IntoIter;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -82,8 +83,29 @@ impl Clone for Control {
 }
 
 impl Control {
+    /// Create a new control.
     pub(crate) fn new(sender: mpsc::Sender<SwarmControlCmd>, metric: Arc<Metric>) -> Self {
         Control { sender, metric }
+    }
+
+    /// Return an iterator that contains all input bytes group by peer.
+    pub fn peer_in_iter(&self) -> IntoIter<PeerId, usize> {
+        self.metric.get_peers_in_list()
+    }
+
+    /// Return an iterator that contains all output bytes group by peer.
+    pub fn peer_out_iter(&self) -> IntoIter<PeerId, usize> {
+        self.metric.get_peers_out_list()
+    }
+
+    /// Return an iterator that contains all input bytes group by protocol.
+    pub fn protocol_in_iter(&self) -> IntoIter<String, usize> {
+        self.metric.get_protocols_in_list()
+    }
+
+    /// Return an iterator that contains all output bytes group by protocol.
+    pub fn protocol_out_iter(&self) -> IntoIter<String, usize> {
+        self.metric.get_protocols_out_list()
     }
 
     /// Get recv package count&bytes

--- a/swarm/src/lib.rs
+++ b/swarm/src/lib.rs
@@ -48,7 +48,7 @@ pub mod connection;
 mod control;
 mod dial;
 mod muxer;
-mod network;
+pub mod network;
 mod registry;
 
 pub mod identify;

--- a/swarm/src/metrics/metric.rs
+++ b/swarm/src/metrics/metric.rs
@@ -1,5 +1,6 @@
 use crate::metrics::metricmap::MetricMap;
 use libp2prs_core::PeerId;
+use std::collections::hash_map::IntoIter;
 use std::fmt;
 use std::ops::Add;
 use std::sync::atomic::Ordering::SeqCst;
@@ -108,6 +109,26 @@ impl Metric {
         let peer_in = self.peer_in.load(peer_id);
         let peer_out = self.peer_out.load(peer_id);
         (peer_in, peer_out)
+    }
+
+    /// Get an iterator that key is peer_id and value is input bytes.
+    pub fn get_peers_in_list(&self) -> IntoIter<PeerId, usize> {
+        self.peer_in.iterator().unwrap()
+    }
+
+    /// Get an iterator that key is peer_id and value is output bytes.
+    pub fn get_peers_out_list(&self) -> IntoIter<PeerId, usize> {
+        self.peer_out.iterator().unwrap()
+    }
+
+    /// Get an iterator that key is protocol and value is input bytes.
+    pub fn get_protocols_in_list(&self) -> IntoIter<String, usize> {
+        self.protocol_in.iterator().unwrap()
+    }
+
+    /// Get an iterator that key is protocol and value is output bytes.
+    pub fn get_protocols_out_list(&self) -> IntoIter<String, usize> {
+        self.protocol_out.iterator().unwrap()
     }
 }
 


### PR DESCRIPTION
Now, we can use Prometheus to monitor our peer. If you want to use it, pass a swarm control at initialization and specify a port at start.